### PR TITLE
Add Habit Reminders Card In Dashboard With Notifications

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -42,6 +42,29 @@
                     <a href="index.html#resources" class="btn btn-primary">View Resources</a>
                 </div>
 
+                <!-- Habit Reminders card -->
+                <div class="dashboard-card habit-reminders-card">
+                    <h3>Habit Reminders</h3>
+                    <p>Set a daily reminder time to check in on your habits.</p>
+
+                    <div class="reminder-controls">
+                        <label for="habitReminderTime" class="reminder-label">Reminder time</label>
+
+                        <input
+                            type="time"
+                            id="habitReminderTime"
+                        >
+
+                        <button class="btn btn-primary" id="saveHabitReminderBtn">
+                            Save Reminder
+                        </button>
+
+                        <p class="reminder-status" id="habitReminderStatus">
+                            Pick a time to save a reminder.
+                        </p>
+                    </div>
+                </div>
+
                 <!-- Admin-only card -->
                 <div class="dashboard-card" id="adminManageCard" style="display:none;">
                     <h3>Manage Content</h3>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -45,10 +45,126 @@ document.getElementById('logoutLink')?.addEventListener('click', async (e) => {
     }
 });
 
+/**
+ * Habit reminder helpers
+ */
+
+// Fire a reminder once per day near the configured time
+function triggerHabitReminderIfNeeded(user, reminderKey, existingConfig) {
+    if (!window.userDataManager) return;
+
+    let config = existingConfig;
+    if (!config) {
+        try {
+            config = JSON.parse(localStorage.getItem(reminderKey) || 'null');
+        } catch {
+            config = null;
+        }
+    }
+
+    if (!config || !config.time) return;
+
+    const now = new Date();
+    const [hours, minutes] = config.time.split(':').map(Number);
+
+    const reminderDate = new Date();
+    reminderDate.setHours(hours || 0, minutes || 0, 0, 0);
+
+    const diffMinutes = Math.abs(now.getTime() - reminderDate.getTime()) / 60000;
+    const todayStr = now.toISOString().split('T')[0];
+
+    // Only remind if within 30 minutes of the time, and not already notified today
+    if (diffMinutes > 30 || config.lastNotifiedDate === todayStr) return;
+
+    const habitsKey = window.userDataManager.getUserStorageKey('reclaim_habits', user.id);
+    const habits = JSON.parse(localStorage.getItem(habitsKey) || '[]');
+    const activeCount = Array.isArray(habits) ? habits.length : 0;
+
+    const message = activeCount > 0
+        ? `You have ${activeCount} active habit${activeCount === 1 ? '' : 's'} today. Take a minute to check in.`
+        : 'You have no active habits yet. You can add one on the Habits page.';
+
+    if ('Notification' in window && Notification.permission === 'granted') {
+        try {
+            new Notification('Habit reminder', { body: message });
+        } catch (err) {
+            console.error('Notification error:', err);
+            alert(message);
+        }
+    } else {
+        alert(message);
+    }
+
+    const updatedConfig = { ...config, lastNotifiedDate: todayStr };
+    localStorage.setItem(reminderKey, JSON.stringify(updatedConfig));
+}
+
+// Wire up the Habit Reminders card UI
+function setupHabitReminderCard(user) {
+    if (!window.userDataManager) return;
+
+    const timeInput = document.getElementById('habitReminderTime');
+    const saveBtn = document.getElementById('saveHabitReminderBtn');
+    const statusEl = document.getElementById('habitReminderStatus');
+
+    // If card isn't present, nothing to do
+    if (!timeInput || !saveBtn || !statusEl) return;
+
+    const reminderKey = window.userDataManager.getUserStorageKey(
+        'reclaim_habit_reminder',
+        user.id
+    );
+
+    let reminderConfig = null;
+
+    // Load saved config
+    try {
+        reminderConfig = JSON.parse(localStorage.getItem(reminderKey) || 'null');
+    } catch {
+        reminderConfig = null;
+    }
+
+    // If there is a saved time, show it in the input
+    if (reminderConfig && reminderConfig.time) {
+        // This only runs once during setup, so the user can still change it
+        timeInput.value = reminderConfig.time;
+        statusEl.textContent = `Reminder set for ${reminderConfig.time} each day.`;
+    }
+
+    // Save handler
+    saveBtn.addEventListener('click', () => {
+        const value = timeInput.value;
+
+        if (!value) {
+            statusEl.textContent = 'Pick a time to save a reminder.';
+            return;
+        }
+
+        const newConfig = {
+            time: value,
+            lastNotifiedDate: reminderConfig?.lastNotifiedDate || null
+        };
+
+        localStorage.setItem(reminderKey, JSON.stringify(newConfig));
+        statusEl.textContent = `Reminder set for ${value} each day.`;
+
+        // Ask for notification permission once when user actively saves a reminder
+        if ('Notification' in window && Notification.permission === 'default') {
+            Notification.requestPermission().catch(err => {
+                console.error('Notification permission error:', err);
+            });
+        }
+
+        reminderConfig = newConfig;
+    });
+
+    // After wiring up, optionally trigger a reminder
+    triggerHabitReminderIfNeeded(user, reminderKey, reminderConfig);
+}
+
 // Load dashboard data
 async function loadDashboard() {
     const user = await checkAuth();
-    
     if (!user) return;
     
     // Display user email
@@ -76,6 +192,9 @@ async function loadDashboard() {
     const completedHabits = JSON.parse(localStorage.getItem(completedStorageKey) || '{}');
     const todayCompleted = completedHabits[today] || [];
     document.getElementById('completedHabitsCount').textContent = todayCompleted.length;
+
+    // Habit Reminders card setup
+    setupHabitReminderCard(user);
 }
 
 // Initialize dashboard

--- a/public/style.css
+++ b/public/style.css
@@ -1312,6 +1312,54 @@ footer {
     margin-bottom: 3rem;
 }
 
+/* Habit Reminders card: span full row under the top 3 and be a bit shorter */
+.habit-reminders-card {
+    grid-column: 1 / -1;         
+    max-width: 900px;            
+    justify-self: center;         
+    padding: 1.75rem 2.5rem;      
+}
+
+.habit-reminders-card p {
+    margin-bottom: 0.75rem;
+}
+
+
+.habit-reminders-card .reminder-controls {
+    max-width: 420px;        
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;             
+}
+
+.habit-reminders-card .reminder-controls {
+    max-width: 420px;         
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;            
+}
+
+/* Time input styling for clarity */
+#habitReminderTime {
+    padding: 0.8rem 1rem;
+    font-size: 1rem;
+    border: 2px solid #ccc;
+    border-radius: 8px;
+    width: 100%;
+    transition: border-color 0.2s, box-shadow 0.2s;
+    background: white;
+}
+
+#habitReminderTime:focus {
+    border-color: #667eea;
+    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.25);
+    outline: none;
+}
+
+#habitReminderTime:hover {
+    border-color: #667eea;
+}
+
 .dashboard-card {
     background: white;
     border-radius: 15px;
@@ -1399,6 +1447,11 @@ footer {
 
     .dashboard-grid {
         grid-template-columns: 1fr;
+    }
+
+    .habit-reminders-card {
+        grid-column: auto;
+        max-width: 100%;
     }
 
     .stats-grid {


### PR DESCRIPTION
This PR adds a habit reminders card in the user dashboard, that allows users to schedule notifications to their browser at their desired time

Files Changed:

	•	Updated dashboard.html to adjust the Habit Reminders card structure.
	•	Updated style.css to widen the card, improve spacing, and fix the squished button.
	•	Minor adjustments in dashboard.js related to reminder UI handling