### PR TITLE
added daily tracking and confetti to wellness tools

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -1724,3 +1724,42 @@ footer {
   margin: 0;
   padding-left: 1.2rem;
 }
+
+.wellness-tool-streak {
+    margin-top: 0.75rem;
+    margin-bottom: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #4b5563;
+}
+
+.btn-success.completed {
+    background: #6c757d;
+}
+
+.btn-success.completed:hover {
+    background: #6c757d;
+}
+
+.confetti-piece {
+    position: fixed;
+    top: -10px;
+    width: 8px;
+    height: 14px;
+    border-radius: 2px;
+    pointer-events: none;
+    z-index: 2000;
+    opacity: 0.95;
+    animation: confetti-fall 1.6s ease-in forwards;
+}
+
+@keyframes confetti-fall {
+    0% {
+        transform: translateY(0) rotate(0deg);
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(110vh) rotate(720deg);
+        opacity: 0;
+    }
+}

--- a/public/wellnessTools.js
+++ b/public/wellnessTools.js
@@ -1,5 +1,101 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
   const container = document.querySelector(".wellness-tools-grid");
+  if (!container) return;
+
+  const user = await window.userDataManager?.getCurrentUser();
+  const storageKey = window.userDataManager?.getUserStorageKey
+    ? window.userDataManager.getUserStorageKey("reclaim_wellness_tools_progress", user?.id)
+    : "reclaim_wellness_tools_progress";
+
+  function getTodayDateString() {
+    return new Date().toISOString().split("T")[0];
+  }
+
+  function getYesterdayDateString() {
+    const d = new Date();
+    d.setDate(d.getDate() - 1);
+    return d.toISOString().split("T")[0];
+  }
+
+  function loadProgress() {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      const parsed = raw ? JSON.parse(raw) : {};
+      if (!parsed || typeof parsed !== "object") return { tools: {} };
+      if (!parsed.tools || typeof parsed.tools !== "object") {
+        return { tools: {} };
+      }
+      return parsed;
+    } catch {
+      return { tools: {} };
+    }
+  }
+
+  function saveProgress(progress) {
+    localStorage.setItem(storageKey, JSON.stringify(progress));
+  }
+
+  function ensureStreakElement(card) {
+    let streakEl = card.querySelector(".wellness-tool-streak");
+    if (!streakEl) {
+      streakEl = document.createElement("div");
+      streakEl.className = "wellness-tool-streak";
+      const button = card.querySelector(".btn-success");
+      if (button) {
+        button.insertAdjacentElement("beforebegin", streakEl);
+      } else {
+        card.appendChild(streakEl);
+      }
+    }
+    return streakEl;
+  }
+
+  function renderCardState(card, toolProgress) {
+    const button = card.querySelector(".btn-success");
+    if (!button) return;
+
+    const today = getTodayDateString();
+    const streak = Number(toolProgress?.streak || 0);
+    const totalCompletions = Number(toolProgress?.totalCompletions || 0);
+    const completedToday = toolProgress?.lastCompletedDate === today;
+
+    button.textContent = completedToday ? "Completed Today" : "Mark Complete";
+    button.disabled = completedToday;
+    button.classList.toggle("completed", completedToday);
+
+    const streakEl = ensureStreakElement(card);
+    streakEl.textContent = `Streak: ${streak} day${streak === 1 ? "" : "s"} • Total: ${totalCompletions}`;
+  }
+
+  function launchConfetti() {
+    const colors = ["#667eea", "#764ba2", "#28a745", "#ffcc00", "#ff6b6b"];
+    const count = 36;
+
+    for (let i = 0; i < count; i++) {
+      const piece = document.createElement("span");
+      piece.className = "confetti-piece";
+      piece.style.left = `${Math.random() * 100}vw`;
+      piece.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
+      piece.style.animationDelay = `${Math.random() * 0.3}s`;
+      piece.style.transform = `rotate(${Math.random() * 360}deg)`;
+      document.body.appendChild(piece);
+
+      setTimeout(() => {
+        piece.remove();
+      }, 1800);
+    }
+  }
+
+  function getToolIndex(card) {
+    return Array.from(container.children).indexOf(card);
+  }
+
+  let progress = loadProgress();
+
+  Array.from(container.children).forEach((card, index) => {
+    const toolProgress = progress.tools[String(index)] || {};
+    renderCardState(card, toolProgress);
+  });
 
   container.addEventListener("click", (e) => {
     const btn = e.target.closest(".btn-success");
@@ -8,30 +104,30 @@ document.addEventListener("DOMContentLoaded", () => {
     const card = btn.closest(".dashboard-card");
     if (!card) return;
 
-    const index = Array.from(container.children).indexOf(card);
+    const toolIndex = getToolIndex(card);
+    if (toolIndex < 0) return;
 
-    let completedTools = JSON.parse(localStorage.getItem("completedTools") || "[]");
+    const key = String(toolIndex);
+    const existing = progress.tools[key] || {};
+    const today = getTodayDateString();
+    const yesterday = getYesterdayDateString();
 
-    if (!completedTools.includes(index)) {
-      completedTools.push(index);
-      localStorage.setItem("completedTools", JSON.stringify(completedTools));
+    if (existing.lastCompletedDate === today) {
+      return;
     }
 
-    btn.textContent = "Completed";
-    btn.disabled = true;
-    btn.classList.add("completed");
-  });
+    const previousStreak = Number(existing.streak || 0);
+    const nextStreak = existing.lastCompletedDate === yesterday ? previousStreak + 1 : 1;
+    const nextTotal = Number(existing.totalCompletions || 0) + 1;
 
-  const completedTools = JSON.parse(localStorage.getItem("completedTools") || "[]");
-  completedTools.forEach((index) => {
-    const card = container.children[index];
-    if (card) {
-      const btn = card.querySelector(".btn-success");
-      if (btn) {
-        btn.textContent = "Completed";
-        btn.disabled = true;
-        btn.classList.add("completed");
-      }
-    }
+    progress.tools[key] = {
+      lastCompletedDate: today,
+      streak: nextStreak,
+      totalCompletions: nextTotal
+    };
+
+    saveProgress(progress);
+    renderCardState(card, progress.tools[key]);
+    launchConfetti();
   });
 });


### PR DESCRIPTION
i noticed that once you completed a wellness tool activity, the completed box would become grayed out and unable to reclick, no matter if it was a new day or new log in.

- i made it something you can do once a day, it also has tracking for a streak and everytime a user completes it, there will be confetti dropping. 

<img width="1193" height="595" alt="image" src="https://github.com/user-attachments/assets/d2564276-866a-4816-bc9a-4756eadcdbee" />
