### PR TITLE
Update links for Resources section on Journal page

### DIFF
--- a/public/journal.html
+++ b/public/journal.html
@@ -83,26 +83,26 @@
     <section id="resources" class="section">
       <h2>Support Resources</h2>
       <div class="resources-grid">
-        <div class="resource-card">
-          <h3>YFS Health Services</h3>
-          <p>York Federation of Students offers confidential health and wellness support.</p>
-          <a href="#" class="btn">Learn More</a>
-        </div>
-        <div class="resource-card">
-          <h3>Crisis Support</h3>
-          <p>24/7 crisis support line available for immediate help.</p>
-          <a href="#" class="btn">Get Help</a>
-        </div>
-        <div class="resource-card">
-          <h3>Counselling Services</h3>
-          <p>Professional counselling services available to all students.</p>
-          <a href="#" class="btn">Book Session</a>
-        </div>
-        <div class="resource-card">
-          <h3>Wellness Workshops</h3>
-          <p>Join workshops on stress management, time management, and more.</p>
-          <a href="#" class="btn">View Schedule</a>
-        </div>
+          <div class="resource-card">
+            <h3>YFS Health Services</h3>
+            <p>York Federation of Students offers confidential health and wellness support.</p>
+            <a href="https://www.yfs.ca/healthandwellness" class="btn">Learn More</a>
+          </div>
+          <div class="resource-card">
+            <h3>Crisis Support</h3>
+            <p>Good2Talk, a 24/7 crisis support line available for immediate help.</p>
+            <a href="https://good2talk.ca/" class="btn">Get Help</a>
+          </div>
+          <div class="resource-card">
+            <h3>Counselling Services</h3>
+            <p>Professional counselling services available to all students.</p>
+            <a href="https://students.yorku.ca/counselling" class="btn">Book a Session</a>
+          </div>
+          <div class="resource-card">
+            <h3>Wellness Workshops</h3>
+            <p>Join workshops on stress management, time management, and more.</p>
+            <a href="https://students.yorku.ca/counselling/events" class="btn">View Schedule</a>
+          </div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
The Resources section on the Journal page were missing the links to the actual resources.